### PR TITLE
Fix "FML Incompatible modded server" and some NPE crash sources.

### DIFF
--- a/src/main/java/net/silentchaos512/equiptooltips/EquipmentStats.java
+++ b/src/main/java/net/silentchaos512/equiptooltips/EquipmentStats.java
@@ -154,7 +154,7 @@ public class EquipmentStats {
 
         for (Entry<String, AttributeModifier> entry : multimap.entries()) {
             AttributeModifier mod = entry.getValue();
-            if (mod.getID().equals(ATTACK_SPEED_MODIFIER)) {
+            if (mod != null && mod.getID().equals(ATTACK_SPEED_MODIFIER)) {
                 return (float) mod.getAmount() + 4f;
             }
         }
@@ -184,7 +184,7 @@ public class EquipmentStats {
         for (Entry<String, AttributeModifier> entry : multimap.entries()) {
             String key = entry.getKey();
             AttributeModifier mod = entry.getValue();
-            if (key.equals(SharedMonsterAttributes.ARMOR.getName()) && mod.getID().equals(uuid)) {
+            if (mod != null && key.equals(SharedMonsterAttributes.ARMOR.getName()) && mod.getID().equals(uuid)) {
                 return (float) mod.getAmount();
             }
         }
@@ -207,7 +207,7 @@ public class EquipmentStats {
         for (Entry<String, AttributeModifier> entry : multimap.entries()) {
             String key = entry.getKey();
             AttributeModifier mod = entry.getValue();
-            if (key.equals(SharedMonsterAttributes.ARMOR_TOUGHNESS.getName())
+            if (mod != null && key.equals(SharedMonsterAttributes.ARMOR_TOUGHNESS.getName())
                     && mod.getID().equals(uuid)) {
                 return (float) mod.getAmount();
             }

--- a/src/main/java/net/silentchaos512/equiptooltips/EquipmentTooltips.java
+++ b/src/main/java/net/silentchaos512/equiptooltips/EquipmentTooltips.java
@@ -2,13 +2,17 @@ package net.silentchaos512.equiptooltips;
 
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.fml.loading.FMLLoader;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,6 +26,9 @@ public class EquipmentTooltips {
     public static final Logger LOGGER = LogManager.getLogger(MOD_NAME);
 
     public EquipmentTooltips() {
+        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () ->
+                Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
+
         if (FMLEnvironment.dist == Dist.CLIENT) {
             Config.init();
             FMLJavaModLoadingContext.get().getModEventBus().addListener(EquipmentTooltips::onCommonSetup);


### PR DESCRIPTION
Reference: https://mcforge.readthedocs.io/en/latest/concepts/sides/#writing-one-sided-mods

This small change should let FML know that the mod is not required to be on the server.